### PR TITLE
HTML_locale

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const html = {
       table &&
       table.fields.filter(
         (f) =>
-          (f.type || {}).name === "HTML_locale" &&
+          (f.type || {}).name === "HTML" &&
           !(f.attributes && f.attributes.localizes_field)
       );
     const locales = Object.keys(

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const html = {
       table &&
       table.fields.filter(
         (f) =>
-          (f.type || {}).name === "String" &&
+          (f.type || {}).name === "HTML_locale" &&
           !(f.attributes && f.attributes.localizes_field)
       );
     const locales = Object.keys(

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ const html = {
               label: "Translation of",
               sublabel:
                 "This is a translation of a different field in a different language",
-              type: "HTML_locale",
+              type: "String",
               attributes: {
                 options: strFields.map((f) => f.name),
               },

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const { textarea, text, div } = require("@saltcorn/markup/tags");
 const xss = require("xss");
-const { getState } = require("../db/state");
+// const { getState } = require("../db/state");
 
 xss.whiteList.kbd = [];
 xss.whiteList.table = [

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ xss.whiteList.table = [
 ];
 
 const html = {
-  name: "HTML_locale",
+  name: "HTML",
   sql_name: "text",
   attributes: ({ table }) => {
     const strFields =

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const { textarea, text, div } = require("@saltcorn/markup/tags");
 const xss = require("xss");
+const { getState } = require("../db/state");
 
 xss.whiteList.kbd = [];
 xss.whiteList.table = [

--- a/index.js
+++ b/index.js
@@ -13,8 +13,44 @@ xss.whiteList.table = [
 ];
 
 const html = {
-  name: "HTML",
+  name: "HTML_locale",
   sql_name: "text",
+  attributes: ({ table }) => {
+    const strFields =
+      table &&
+      table.fields.filter(
+        (f) =>
+          (f.type || {}).name === "String" &&
+          !(f.attributes && f.attributes.localizes_field)
+      );
+    const locales = Object.keys(
+      getState().getConfig("localizer_languages", {})
+    );
+    return [
+      ...(table
+        ? [
+            {
+              name: "localizes_field",
+              label: "Translation of",
+              sublabel:
+                "This is a translation of a different field in a different language",
+              type: "HTML_locale",
+              attributes: {
+                options: strFields.map((f) => f.name),
+              },
+            },
+            {
+              name: "locale",
+              label: "Locale",
+              sublabel: "Language locale of translation",
+              input_type: "select",
+              options: locales,
+              showIf: { localizes_field: strFields.map((f) => f.name) },
+            },
+          ]
+        : []),
+    ];
+  },
   fieldviews: {
     showAll: {
       isEdit: false,

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const { textarea, text, div } = require("@saltcorn/markup/tags");
 const xss = require("xss");
-// const { getState } = require("../db/state");
+const { getState } = require("@saltcorn/data/db/state");
 
 xss.whiteList.kbd = [];
 xss.whiteList.table = [

--- a/package.json
+++ b/package.json
@@ -1,19 +1,19 @@
 {
-  "name": "@saltcorn/html",
+  "name": "@saltcorn/html_locale",
   "version": "0.1.8",
-  "description": "HTML field plugin",
+  "description": "HTML field plugin which localizes",
   "main": "index.js",
   "dependencies": {
     "@saltcorn/markup": "^0.0.8",
     "xss": "^1.0.6"
   },
-  "author": "Tom Nielsen",
+  "author": "PM",
   "license": "MIT",
   "devDependencies": {
     "jest": "^25.1.0",
     "@saltcorn/data": "^0.0.8"
   },
-  "repository": "github:saltcorn/html",
+  "repository": "github:vocamen/html",
   "jest": {
     "testEnvironment": "node"
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@saltcorn/html_locale",
+  "name": "@vocamen/html_locale",
   "version": "0.1.8",
   "description": "HTML field plugin which localizes",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,19 +1,20 @@
 {
-  "name": "@vocamen/html",
-  "version": "0.3",
-  "description": "HTML field plugin which localizes",
+  "name": "@saltcorn/html",
+  "version": "0.1.8",
+  "description": "HTML field plugin",
   "main": "index.js",
   "dependencies": {
     "@saltcorn/markup": "^0.0.8",
     "xss": "^1.0.6"
   },
-  "author": "PM",
+  "author": "Tom Nielsen",
+  "contributors": ["PM <contact@vocamen.com> (https://www.vocamen.com)"],
   "license": "MIT",
   "devDependencies": {
     "jest": "^25.1.0",
     "@saltcorn/data": "^0.0.8"
   },
-  "repository": "github:vocamen/html",
+  "repository": "github:saltcorn/html",
   "jest": {
     "testEnvironment": "node"
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@vocamen/html_locale",
+  "name": "@vocamen/html",
   "version": "0.3",
   "description": "HTML field plugin which localizes",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vocamen/html_locale",
-  "version": "0.1.8",
+  "version": "0.2",
   "description": "HTML field plugin which localizes",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vocamen/html_locale",
-  "version": "0.2",
+  "version": "0.3",
   "description": "HTML field plugin which localizes",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
It takes care of localizing HTML field which is needed when you translate more than string fields.

Markdown should also get the same treatment :smile: 